### PR TITLE
Removed deprecated members.

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -75,14 +75,6 @@ $functions = array(
         'type'          => 'read',
         'capabilities'  => 'mod/forum:viewdiscussion, mod/forum:viewqandawithoutposting',
     ),
-    'local_aspiredu_core_course_get_category_courses' => array(
-        'classname'     => 'local_aspiredu_external',
-        'methodname'    => 'core_course_get_category_courses',
-        'classpath'     => 'local/aspiredu/externallib.php',
-        'description'   => 'Returns a list of courses in a category (or subcategories of the main category).',
-        'type'          => 'read',
-        'capabilities'  => '',
-    ),
     'local_aspiredu_core_get_legacy_logs' => array(
         'classname'     => 'local_aspiredu_external',
         'methodname'    => 'core_get_legacy_logs',
@@ -168,7 +160,6 @@ $services = array(
             'local_aspiredu_gradereport_user_get_grades_table',
             'local_aspiredu_core_grades_get_grades',
             'local_aspiredu_core_group_get_course_user_groups',
-            'local_aspiredu_core_course_get_category_courses',
             'local_aspiredu_core_get_legacy_logs',
             'local_aspiredu_report_log_get_log_records',
             'local_aspiredu_mod_assign_get_assignments',

--- a/externallib.php
+++ b/externallib.php
@@ -315,8 +315,8 @@ class local_aspiredu_external extends external_api {
                                 PARAM_ALPHANUM, 'The ID of the activity or "course" for the course grade item'),
                             'itemnumber'  => new external_value(PARAM_INT, 'Will be 0 unless the module has multiple grades'),
                             'scaleid' => new external_value(PARAM_INT, 'The ID of the custom scale or 0'),
-                            'name' => new external_value(PARAM_RAW, 'The module name'),
-                            'modname' => new external_value(PARAM_RAW, 'The module name', VALUE_OPTIONAL),
+                            'name' => new external_value(PARAM_TEXT, 'The module name'),
+                            'modname' => new external_value(PARAM_TEXT, 'The module name', VALUE_OPTIONAL),
                             'instance' => new external_value(PARAM_INT, 'module instance id', VALUE_OPTIONAL),
                             'grademin' => new external_value(PARAM_FLOAT, 'Minimum grade'),
                             'grademax' => new external_value(PARAM_FLOAT, 'Maximum grade'),
@@ -337,7 +337,7 @@ class local_aspiredu_external extends external_api {
                                         'overridden' => new external_value(
                                             PARAM_INT, '0 means not overridden, > 1 means overridden'),
                                         'feedback' => new external_value(
-                                            PARAM_RAW, 'Feedback from the grader'),
+                                            PARAM_CLEANHTML, 'Feedback from the grader'),
                                         'feedbackformat' => new external_value(
                                             PARAM_INT, 'The format of the feedback'),
                                         'usermodified' => new external_value(
@@ -347,11 +347,11 @@ class local_aspiredu_external extends external_api {
                                         'dategraded' => new external_value(
                                             PARAM_INT, 'A timestamp indicating when the assignment was grades'),
                                         'str_grade' => new external_value(
-                                            PARAM_RAW, 'A string representation of the grade'),
+                                            PARAM_TEXT, 'A string representation of the grade'),
                                         'str_long_grade' => new external_value(
-                                            PARAM_RAW, 'A nicely formatted string representation of the grade'),
+                                            PARAM_TEXT, 'A nicely formatted string representation of the grade'),
                                         'str_feedback' => new external_value(
-                                            PARAM_RAW, 'A formatted string representation of the feedback from the grader'),
+                                            PARAM_CLEANHTML, 'A formatted string representation of the feedback from the grader'),
                                     )
                                 )
                             ),
@@ -365,7 +365,7 @@ class local_aspiredu_external extends external_api {
                                 PARAM_ALPHANUM, 'The ID of the activity or "course" for the course grade item'),
                             'itemnumber'  => new external_value(PARAM_INT, 'Will be 0 unless the module has multiple grades'),
                             'scaleid' => new external_value(PARAM_INT, 'The ID of the custom scale or 0'),
-                            'name' => new external_value(PARAM_RAW, 'The module name'),
+                            'name' => new external_value(PARAM_TEXT, 'The module name'),
                             'locked' => new external_value(PARAM_INT, '0 means not locked, > 1 is a date to lock until'),
                             'hidden' => new external_value(PARAM_INT, '0 means not hidden, > 1 is a date to hide until'),
                             'grades' => new external_multiple_structure(
@@ -380,15 +380,15 @@ class local_aspiredu_external extends external_api {
                                         'hidden' => new external_value(
                                             PARAM_INT, '0 means not hidden, 1 hidden, > 1 is a date to hide until'),
                                         'feedback' => new external_value(
-                                            PARAM_RAW, 'Feedback from the grader'),
+                                            PARAM_CLEANHTML, 'Feedback from the grader'),
                                         'feedbackformat' => new external_value(
                                             PARAM_INT, 'The feedback format'),
                                         'usermodified' => new external_value(
                                             PARAM_INT, 'The ID of the last user to modify this student grade'),
                                         'str_grade' => new external_value(
-                                            PARAM_RAW, 'A string representation of the grade'),
+                                            PARAM_TEXT, 'A string representation of the grade'),
                                         'str_feedback' => new external_value(
-                                            PARAM_RAW, 'A formatted string representation of the feedback from the grader'),
+                                            PARAM_CLEANHTML, 'A formatted string representation of the feedback from the grader'),
                                     )
                                 )
                             ),
@@ -588,7 +588,7 @@ class local_aspiredu_external extends external_api {
                         new external_single_structure(
                             array(
                                 'id' => new external_value(PARAM_INT, 'Post id'),
-                                'name' => new external_value(PARAM_RAW, 'Discussion name'),
+                                'name' => new external_value(PARAM_TEXT, 'Discussion name'),
                                 'groupid' => new external_value(PARAM_INT, 'Group id'),
                                 'timemodified' => new external_value(PARAM_INT, 'Time modified'),
                                 'usermodified' => new external_value(PARAM_INT, 'The id of the user who last modified'),
@@ -600,16 +600,16 @@ class local_aspiredu_external extends external_api {
                                 'created' => new external_value(PARAM_INT, 'Creation time'),
                                 'modified' => new external_value(PARAM_INT, 'Time modified'),
                                 'mailed' => new external_value(PARAM_INT, 'Mailed?'),
-                                'subject' => new external_value(PARAM_RAW, 'The post subject'),
-                                'message' => new external_value(PARAM_RAW, 'The post message'),
+                                'subject' => new external_value(PARAM_CLEANHTML, 'The post subject'),
+                                'message' => new external_value(PARAM_CLEANHTML, 'The post message'),
                                 'messageformat' => new external_format_value('message'),
                                 'messagetrust' => new external_value(PARAM_INT, 'Can we trust?'),
-                                'attachment' => new external_value(PARAM_RAW, 'Has attachments?'),
+                                'attachment' => new external_value(PARAM_TEXT, 'Has attachments?'),
                                 'attachments' => new external_multiple_structure(
                                     new external_single_structure(
                                         array (
                                             'filename' => new external_value(PARAM_FILE, 'file name'),
-                                            'mimetype' => new external_value(PARAM_RAW, 'mime type'),
+                                            'mimetype' => new external_value(PARAM_TEXT, 'mime type'),
                                             'fileurl'  => new external_value(PARAM_URL, 'file download url')
                                         )
                                     ), 'attachments', VALUE_OPTIONAL
@@ -811,16 +811,16 @@ class local_aspiredu_external extends external_api {
                                 'created' => new external_value(PARAM_INT, 'Creation time'),
                                 'modified' => new external_value(PARAM_INT, 'Time modified'),
                                 'mailed' => new external_value(PARAM_INT, 'Mailed?'),
-                                'subject' => new external_value(PARAM_RAW, 'The post subject'),
-                                'message' => new external_value(PARAM_RAW, 'The post message'),
+                                'subject' => new external_value(PARAM_CLEANHTML, 'The post subject'),
+                                'message' => new external_value(PARAM_CLEANHTML, 'The post message'),
                                 'messageformat' => new external_format_value('message'),
                                 'messagetrust' => new external_value(PARAM_INT, 'Can we trust?'),
-                                'attachment' => new external_value(PARAM_RAW, 'Has attachments?'),
+                                'attachment' => new external_value(PARAM_TEXT, 'Has attachments?'),
                                 'attachments' => new external_multiple_structure(
                                     new external_single_structure(
                                         array (
                                             'filename' => new external_value(PARAM_FILE, 'file name'),
-                                            'mimetype' => new external_value(PARAM_RAW, 'mime type'),
+                                            'mimetype' => new external_value(PARAM_TEXT, 'mime type'),
                                             'fileurl'  => new external_value(PARAM_URL, 'file download url')
                                         )
                                     ), 'attachments', VALUE_OPTIONAL
@@ -939,8 +939,8 @@ class local_aspiredu_external extends external_api {
                     'id' => new external_value(PARAM_INT, 'Forum id'),
                     'course' => new external_value(PARAM_TEXT, 'Course id'),
                     'type' => new external_value(PARAM_TEXT, 'The forum type'),
-                    'name' => new external_value(PARAM_RAW, 'Forum name'),
-                    'intro' => new external_value(PARAM_RAW, 'The forum intro'),
+                    'name' => new external_value(PARAM_TEXT, 'Forum name'),
+                    'intro' => new external_value(PARAM_CLEANHTML, 'The forum intro'),
                     'introformat' => new external_format_value('intro'),
                     'assessed' => new external_value(PARAM_INT, 'Aggregate type'),
                     'assesstimestart' => new external_value(PARAM_INT, 'Assess start time'),
@@ -1058,7 +1058,7 @@ class local_aspiredu_external extends external_api {
                         array(
                             'id' => new external_value(PARAM_INT, 'group record id'),
                             'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
-                            'description' => new external_value(PARAM_RAW, 'group description text'),
+                            'description' => new external_value(PARAM_CLEANHTML, 'group description text'),
                             'descriptionformat' => new external_format_value('description')
                         )
                     )
@@ -1214,9 +1214,9 @@ class local_aspiredu_external extends external_api {
      */
     private static function grades_table_column() {
         return array (
-            'class'   => new external_value(PARAM_RAW, 'class'),
-            'content' => new external_value(PARAM_RAW, 'cell content'),
-            'headers' => new external_value(PARAM_RAW, 'headers')
+            'class'   => new external_value(PARAM_TEXT, 'class'),
+            'content' => new external_value(PARAM_TEXT, 'cell content'),
+            'headers' => new external_value(PARAM_TEXT, 'headers')
         );
     }
 
@@ -1241,16 +1241,16 @@ class local_aspiredu_external extends external_api {
                                     array(
                                         'itemname' => new external_single_structure(
                                             array (
-                                                'class' => new external_value(PARAM_RAW, 'file name'),
+                                                'class' => new external_value(PARAM_TEXT, 'file name'),
                                                 'colspan' => new external_value(PARAM_INT, 'mime type'),
-                                                'content'  => new external_value(PARAM_RAW, ''),
-                                                'celltype'  => new external_value(PARAM_RAW, ''),
+                                                'content'  => new external_value(PARAM_CLEANHTML, ''),
+                                                'celltype'  => new external_value(PARAM_TEXT, ''),
                                                 'id'  => new external_value(PARAM_ALPHANUMEXT, '')
                                             ), 'The item returned data', VALUE_OPTIONAL
                                         ),
                                         'leader' => new external_single_structure(
                                             array (
-                                                'class' => new external_value(PARAM_RAW, 'file name'),
+                                                'class' => new external_value(PARAM_TEXT, 'file name'),
                                                 'rowspan' => new external_value(PARAM_INT, 'mime type')
                                             ), 'The item returned data', VALUE_OPTIONAL
                                         ),
@@ -1292,80 +1292,6 @@ class local_aspiredu_external extends external_api {
         );
     }
 
-    /**
-     * Returns description of method parameters
-     *
-     * @return external_function_parameters
-     */
-    public static function core_course_get_category_courses_parameters() {
-        return new external_function_parameters(
-            array(
-                'categoryid' => new external_value(PARAM_INT, 'id of the category')
-            )
-        );
-    }
-
-    /**
-     * Get all courses in the specified category
-     *
-     * @param int $categoryid id of the category
-     * @return array of course objects (id, name ...) and warnings
-     */
-    public static function core_course_get_category_courses($categoryid) {
-        $warnings = array();
-
-        $params = array(
-            'categoryid' => $categoryid
-        );
-        $params = self::validate_parameters(self::core_course_get_category_courses_parameters(), $params);
-        $categoryid = $params['categoryid'];
-
-        // Security checks.
-        $context = context_coursecat::instance($categoryid);
-        self::validate_context($context);
-
-        $courses = get_courses($categoryid, 'c.sortorder ASC', 'c.id');
-        $courseids = array_keys($courses);
-
-        foreach ($courseids as $key => $cid) {
-            $coursecontext = context_course::instance($cid);
-            try {
-                self::validate_context($coursecontext);
-            } catch (Exception $e) {
-                unset($courseids[$key]);
-                continue;
-            }
-            if (!has_capability('moodle/course:view', $coursecontext)) {
-                unset($courseids[$key]);
-            }
-        }
-
-        $options = array(
-            'ids' => $courseids
-        );
-        // Call the core function for retrieving the complete course information.
-        $courses = core_course_external::get_courses($options);
-
-        $results = array(
-            'courses' => $courses,
-            'warnings' => $warnings
-        );
-        return $results;
-    }
-
-    /**
-     * Returns description of method result value
-     *
-     * @return external_description
-     */
-    public static function core_course_get_category_courses_returns() {
-        return new external_single_structure(
-            array(
-                'courses' => core_course_external::get_courses_returns(),
-                'warnings' => new external_warnings(),
-            )
-        );
-    }
 
     /**
      * Returns description of method parameters
@@ -1465,13 +1391,13 @@ class local_aspiredu_external extends external_api {
                             'id' => new external_value(PARAM_INT, ''),
                             'time' => new external_value(PARAM_INT, ''),
                             'userid' => new external_value(PARAM_INT, ''),
-                            'ip' => new external_value(PARAM_RAW, ''),
+                            'ip' => new external_value(PARAM_TEXT, ''),
                             'course' => new external_value(PARAM_INT, ''),
-                            'module' => new external_value(PARAM_RAW, ''),
-                            'cmid' => new external_value(PARAM_RAW, ''),
+                            'module' => new external_value(PARAM_TEXT, ''),
+                            'cmid' => new external_value(PARAM_TEXT, ''),
                             'action' => new external_value(PARAM_TEXT, ''),
-                            'url' => new external_value(PARAM_RAW, ''),
-                            'info' => new external_value(PARAM_RAW, ''),
+                            'url' => new external_value(PARAM_TEXT, ''),
+                            'info' => new external_value(PARAM_TEXT, ''),
                         )
                     )
                 ),
@@ -1614,14 +1540,14 @@ class local_aspiredu_external extends external_api {
                 'logs' => new external_multiple_structure(
                     new external_single_structure(
                         array(
-                            'eventname' => new external_value(PARAM_RAW, 'eventname'),
-                            'name' => new external_value(PARAM_RAW, 'get_name()'),
-                            'description' => new external_value(PARAM_RAW, 'get_description()'),
+                            'eventname' => new external_value(PARAM_TEXT, 'eventname'),
+                            'name' => new external_value(PARAM_TEXT, 'get_name()'),
+                            'description' => new external_value(PARAM_TEXT, 'get_description()'),
                             'component' => new external_value(PARAM_COMPONENT, 'component'),
-                            'action' => new external_value(PARAM_RAW, 'action'),
-                            'target' => new external_value(PARAM_RAW, 'target'),
-                            'objecttable' => new external_value(PARAM_RAW, 'objecttable'),
-                            'objectid' => new external_value(PARAM_RAW, 'objectid'),
+                            'action' => new external_value(PARAM_TEXT, 'action'),
+                            'target' => new external_value(PARAM_TEXT, 'target'),
+                            'objecttable' => new external_value(PARAM_TEXT, 'objecttable'),
+                            'objectid' => new external_value(PARAM_TEXT, 'objectid'),
                             'crud' => new external_value(PARAM_ALPHA, 'crud'),
                             'edulevel' => new external_value(PARAM_INT, 'edulevel'),
                             'contextid' => new external_value(PARAM_INT, 'contextid'),
@@ -1631,7 +1557,7 @@ class local_aspiredu_external extends external_api {
                             'courseid' => new external_value(PARAM_INT, 'courseid'),
                             'relateduserid' => new external_value(PARAM_INT, 'relateduserid'),
                             'anonymous' => new external_value(PARAM_INT, 'anonymous'),
-                            'other' => new external_value(PARAM_RAW, 'other'),
+                            'other' => new external_value(PARAM_TEXT, 'other'),
                             'timecreated' => new external_value(PARAM_INT, 'timecreated'),
                         )
                     )
@@ -1808,7 +1734,7 @@ class local_aspiredu_external extends external_api {
             array(
                 'id' => new external_value(PARAM_INT, 'assignment id'),
                 'course' => new external_value(PARAM_INT, 'course id'),
-                'name' => new external_value(PARAM_RAW, 'assignment name'),
+                'name' => new external_value(PARAM_TEXT, 'assignment name'),
                 'nosubmissions' => new external_value(PARAM_INT, 'no submissions'),
                 'submissiondrafts' => new external_value(PARAM_INT, 'submissions drafts'),
                 'sendnotifications' => new external_value(PARAM_INT, 'send notifications'),
@@ -2018,11 +1944,13 @@ class local_aspiredu_external extends external_api {
 
                         $editorfields = $submissionplugin->get_editor_fields();
                         foreach ($editorfields as $name => $description) {
+                            $textformat = $submissionplugin->get_editor_format($name, $submissionrecord->id);
+                            format_text('', 0);
                             $editorfieldinfo = array(
                                 'name' => $name,
                                 'description' => $description,
-                                'text' => $submissionplugin->get_editor_text($name, $submissionrecord->id),
-                                'format' => $submissionplugin->get_editor_format($name, $submissionrecord->id)
+                                'text' => format_text($submissionplugin->get_editor_text($name, $submissionrecord->id), $textformat),
+                                'format' => $textformat
                             );
                             $plugin['editorfields'][] = $editorfieldinfo;
                         }
@@ -2085,7 +2013,7 @@ class local_aspiredu_external extends external_api {
                                                     'files' => new external_multiple_structure(
                                                         new external_single_structure(
                                                             array (
-                                                                'filepath' => new external_value (PARAM_TEXT, 'file path')
+                                                                'filepath' => new external_value(PARAM_TEXT, 'file path')
                                                             )
                                                         ), 'files', VALUE_OPTIONAL
                                                     )
@@ -2097,8 +2025,8 @@ class local_aspiredu_external extends external_api {
                                                 array(
                                                     'name' => new external_value(PARAM_TEXT, 'field name'),
                                                     'description' => new external_value(PARAM_TEXT, 'field description'),
-                                                    'text' => new external_value (PARAM_RAW, 'field value'),
-                                                    'format' => new external_format_value ('text')
+                                                    'text' => new external_value(PARAM_CLEANHTML, 'field value'),
+                                                    'format' => new external_format_value('text')
                                                 )
                                             )
                                             , 'editorfields', VALUE_OPTIONAL
@@ -2308,7 +2236,7 @@ class local_aspiredu_external extends external_api {
                         'id' => new external_value(PARAM_INT, 'The course module id'),
                         'course' => new external_value(PARAM_INT, 'The course id'),
                         'module' => new external_value(PARAM_INT, 'The module type id'),
-                        'name' => new external_value(PARAM_RAW, 'The activity name'),
+                        'name' => new external_value(PARAM_TEXT, 'The activity name'),
                         'modname' => new external_value(PARAM_COMPONENT, 'The module component name (forum, assign, etc..)'),
                         'instance' => new external_value(PARAM_INT, 'The activity instance id'),
                         'section' => new external_value(PARAM_INT, 'The module section id'),
@@ -2316,7 +2244,7 @@ class local_aspiredu_external extends external_api {
                         'groupmode' => new external_value(PARAM_INT, 'Group mode'),
                         'groupingid' => new external_value(PARAM_INT, 'Grouping id'),
                         'completion' => new external_value(PARAM_INT, 'If completion is enabled'),
-                        'idnumber' => new external_value(PARAM_RAW, 'Module id number', VALUE_OPTIONAL),
+                        'idnumber' => new external_value(PARAM_TEXT, 'Module id number', VALUE_OPTIONAL),
                         'added' => new external_value(PARAM_INT, 'Time added', VALUE_OPTIONAL),
                         'score' => new external_value(PARAM_INT, 'Score', VALUE_OPTIONAL),
                         'indent' => new external_value(PARAM_INT, 'Indentation', VALUE_OPTIONAL),
@@ -2326,7 +2254,7 @@ class local_aspiredu_external extends external_api {
                         'completionview' => new external_value(PARAM_INT, 'Completion view setting', VALUE_OPTIONAL),
                         'completionexpected' => new external_value(PARAM_INT, 'Completion time expected', VALUE_OPTIONAL),
                         'showdescription' => new external_value(PARAM_INT, 'If the description is showed', VALUE_OPTIONAL),
-                        'availability' => new external_value(PARAM_RAW, 'Availability settings', VALUE_OPTIONAL),
+                        'availability' => new external_value(PARAM_TEXT, 'Availability settings', VALUE_OPTIONAL),
                     )
                 ),
                 'warnings' => new external_warnings()
@@ -2412,7 +2340,7 @@ class local_aspiredu_external extends external_api {
                         'id' => new external_value(PARAM_INT, 'The course module id'),
                         'course' => new external_value(PARAM_INT, 'The course id'),
                         'module' => new external_value(PARAM_INT, 'The module type id'),
-                        'name' => new external_value(PARAM_RAW, 'The activity name'),
+                        'name' => new external_value(PARAM_TEXT, 'The activity name'),
                         'modname' => new external_value(PARAM_COMPONENT, 'The module component name (forum, assign, etc..)'),
                         'instance' => new external_value(PARAM_INT, 'The activity instance id'),
                         'section' => new external_value(PARAM_INT, 'The module section id'),
@@ -2420,7 +2348,7 @@ class local_aspiredu_external extends external_api {
                         'groupmode' => new external_value(PARAM_INT, 'Group mode'),
                         'groupingid' => new external_value(PARAM_INT, 'Grouping id'),
                         'completion' => new external_value(PARAM_INT, 'If completion is enabled'),
-                        'idnumber' => new external_value(PARAM_RAW, 'Module id number', VALUE_OPTIONAL),
+                        'idnumber' => new external_value(PARAM_TEXT, 'Module id number', VALUE_OPTIONAL),
                         'added' => new external_value(PARAM_INT, 'Time added', VALUE_OPTIONAL),
                         'score' => new external_value(PARAM_INT, 'Score', VALUE_OPTIONAL),
                         'indent' => new external_value(PARAM_INT, 'Indentation', VALUE_OPTIONAL),
@@ -2430,7 +2358,7 @@ class local_aspiredu_external extends external_api {
                         'completionview' => new external_value(PARAM_INT, 'Completion view setting', VALUE_OPTIONAL),
                         'completionexpected' => new external_value(PARAM_INT, 'Completion time expected', VALUE_OPTIONAL),
                         'showdescription' => new external_value(PARAM_INT, 'If the description is showed', VALUE_OPTIONAL),
-                        'availability' => new external_value(PARAM_RAW, 'Availability settings', VALUE_OPTIONAL),
+                        'availability' => new external_value(PARAM_TEXT, 'Availability settings', VALUE_OPTIONAL),
                     )
                 ),
                 'warnings' => new external_warnings()
@@ -2587,7 +2515,7 @@ class local_aspiredu_external extends external_api {
         return new external_single_structure(
             array(
                 'scaleid' => new external_value(PARAM_INT, 'The ID of the custom scale or 0'),
-                'name' => new external_value(PARAM_RAW, 'The module name'),
+                'name' => new external_value(PARAM_TEXT, 'The module name'),
                 'grademin' => new external_value(PARAM_FLOAT, 'Minimum grade'),
                 'grademax' => new external_value(PARAM_FLOAT, 'Maximum grade'),
                 'gradepass' => new external_value(PARAM_FLOAT, 'The passing grade threshold'),
@@ -2609,7 +2537,7 @@ class local_aspiredu_external extends external_api {
                             'overridden' => new external_value(
                                 PARAM_INT, '0 means not overridden, > 1 means overridden'),
                             'feedback' => new external_value(
-                                PARAM_RAW, 'Feedback from the grader'),
+                                PARAM_CLEANHTML, 'Feedback from the grader'),
                             'feedbackformat' => new external_value(
                                 PARAM_INT, 'The format of the feedback'),
                             'usermodified' => new external_value(
@@ -2619,11 +2547,11 @@ class local_aspiredu_external extends external_api {
                             'dategraded' => new external_value(
                                 PARAM_INT, 'A timestamp indicating when the assignment was grades'),
                             'str_grade' => new external_value(
-                                PARAM_RAW, 'A string representation of the grade'),
+                                PARAM_TEXT, 'A string representation of the grade'),
                             'str_long_grade' => new external_value(
-                                PARAM_RAW, 'A nicely formatted string representation of the grade'),
+                                PARAM_TEXT, 'A nicely formatted string representation of the grade'),
                             'str_feedback' => new external_value(
-                                PARAM_RAW, 'A formatted string representation of the feedback from the grader'),
+                                PARAM_CLEANHTML, 'A formatted string representation of the feedback from the grader'),
                         )
                     ), 'user grades', VALUE_OPTIONAL
                 ),

--- a/settings.php
+++ b/settings.php
@@ -31,16 +31,16 @@ if ($hassiteconfig) {
     $ADMIN->add('localplugins', $settings);
 
     $settings->add(new admin_setting_configtext('local_aspiredu/dropoutdetectiveurl',
-        get_string('dropoutdetectiveurl', 'local_aspiredu'), '', '', PARAM_RAW_TRIMMED));
+        get_string('dropoutdetectiveurl', 'local_aspiredu'), '', '', PARAM_TEXT));
 
     $settings->add(new admin_setting_configtext('local_aspiredu/instructorinsighturl',
-        get_string('instructorinsighturl', 'local_aspiredu'), '', '', PARAM_RAW_TRIMMED));
+        get_string('instructorinsighturl', 'local_aspiredu'), '', '', PARAM_TEXT));
 
     $settings->add(new admin_setting_configtext('local_aspiredu/key',
-        get_string('key', 'local_aspiredu'), '', '', PARAM_RAW_TRIMMED));
+        get_string('key', 'local_aspiredu'), '', '', PARAM_TEXT));
 
     $settings->add(new admin_setting_configtext('local_aspiredu/secret',
-        get_string('secret', 'local_aspiredu'), '', '', PARAM_RAW_TRIMMED));
+        get_string('secret', 'local_aspiredu'), '', '', PARAM_TEXT));
 
     $options = array(
         0 => get_string('disabled', 'local_aspiredu'),

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version  = 2021051000;
+$plugin->version  = 2021051006;
 $plugin->requires = 2015111600; // 3.0
 $plugin->component = 'local_aspiredu';
 $plugin->release = '3.3.0';


### PR DESCRIPTION
PARAM_RAW and PARAM_RAW_TRIMMED have been deprecated. PARAM_CLEANHTML,
PARAM_TEXT and PARAM_INT should be used instead.

The function coursecat is also deprecated. Since we aren't using it, I'm removing
the exposed service function that would use it.