### PR TITLE
Define a new capability to decide who belongs in Access Management.

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -46,4 +46,15 @@ $capabilities = [
             'manager' => CAP_ALLOW,
         ],
     ],
+    // This role isn't used in the plugin, but by the AspirEDU
+    // server to identify which users should be pulled into the
+    // Access Management area of the products for further permission
+    // configuration.
+    'local/aspiredu:inaccessmanagement' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
+    ],
 ];

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2024010900;
+$plugin->version = 2024012500;
 $plugin->requires = 2022041900.00;
 $plugin->component = 'local_aspiredu';
 $plugin->release = '5.1.0';


### PR DESCRIPTION
The viewdropoutdetective and viewinstructorinsight capabilities are utilized to determine when to render DD/II. This new capability will define who is pulled into Access Management from within DD and II for further permission configuration.